### PR TITLE
Adding virtual host for mail subdomains

### DIFF
--- a/apache/custom/virtual_host2.conf.CUSTOM.4.post
+++ b/apache/custom/virtual_host2.conf.CUSTOM.4.post
@@ -9,3 +9,15 @@
        SuexecUserGroup webapps webapps
    </IfModule>
 </VirtualHost>
+
+<VirtualHost |IP|:|PORT_80| |MULTI_IP|>
+   ServerName mail.|DOMAIN|
+   ServerAdmin |ADMIN|
+   DocumentRoot /var/www/html/roundcube
+   CustomLog /var/log/httpd/domains/|DOMAIN|.bytes bytes
+   CustomLog /var/log/httpd/domains/|DOMAIN|.log combined
+   ErrorLog /var/log/httpd/domains/|DOMAIN|.error.log
+   <IfModule !mod_ruid2.c>
+       SuexecUserGroup webapps webapps
+   </IfModule>
+</VirtualHost>

--- a/apache/custom/virtual_host2_secure.conf.CUSTOM.4.post
+++ b/apache/custom/virtual_host2_secure.conf.CUSTOM.4.post
@@ -15,3 +15,21 @@
        SuexecUserGroup webapps webapps
    </IfModule>
 </VirtualHost>
+
+<VirtualHost |IP|:|PORT_443| |MULTI_IP|>
+   ServerName mail.|DOMAIN|
+   ServerAdmin |ADMIN|
+   DocumentRoot /var/www/html/roundcube
+
+   SSLEngine on
+   SSLCertificateFile |CERT|
+   SSLCertificateKeyFile |KEY|
+   |CAROOT|
+
+   CustomLog /var/log/httpd/domains/|DOMAIN|.bytes bytes
+   CustomLog /var/log/httpd/domains/|DOMAIN|.log combined
+   ErrorLog /var/log/httpd/domains/|DOMAIN|.error.log
+   <IfModule !mod_ruid2.c>
+       SuexecUserGroup webapps webapps
+   </IfModule>
+</VirtualHost>


### PR DESCRIPTION
Since redirects keep triggering phishing complaints, weird. Let's just make a virtual host so users are no longer confused by testing mail subdomains in their web browsers.