### PR TITLE
Reject mail to .local TLD

### DIFF
--- a/exim/exim.acl_check_recipient.pre.conf
+++ b/exim/exim.acl_check_recipient.pre.conf
@@ -197,6 +197,12 @@ deny    condition = ${if match{$sender_helo_name}{(?:^|\.)\mxrouting.net}}
 deny    domains = ^example\.com
         message = Sending to domains starting with "example.com" is not allowed.
 
+# Reject mail to .local TLD. RFC 6762 reserves .local for mDNS; it's not a valid
+# public email destination. Traffic here is always either misconfiguration or abuse.
+deny    condition = ${if match{${lc:$domain}}{\N\.local$\N}{yes}{no}}
+        message = Sending to .local TLD is not allowed (reserved for mDNS per RFC 6762)
+        logwrite = Blocked .local recipient: $local_part@$domain from $sender_host_address
+
 deny    sender_domains = *cloudwaysapps.com
         message = Please use a real sending domain
 


### PR DESCRIPTION
Adds an ACL to reject recipient addresses ending in `.local`.

`.local` is reserved for mDNS per RFC 6762 and is never a valid public email destination. Mail to `.local` recipients is always either a misconfiguration or an abuse vector (leaked internal addresses hitting the public SMTP surface).

Rule placed alongside the existing per-recipient-domain blocks in the `check_recipient` ACL.