### PR TITLE
Reject recipients without a TLD

### DIFF
--- a/exim/exim.acl_check_recipient.pre.conf
+++ b/exim/exim.acl_check_recipient.pre.conf
@@ -203,6 +203,12 @@ deny    condition = ${if match{${lc:$domain}}{\N\.local$\N}{yes}{no}}
         message = Sending to .local TLD is not allowed (reserved for mDNS per RFC 6762)
         logwrite = Blocked .local recipient: $local_part@$domain from $sender_host_address
 
+# Reject recipient domains with no TLD (e.g. localhost, Ubuntu24). These cannot
+# be delivered anywhere public and just junk up the queue on their way to bouncing.
+deny    condition = ${if match{$domain}{\N^[^.]+$\N}{yes}{no}}
+        message = Recipient domain must be a fully qualified name
+        logwrite = Blocked TLD-less recipient: $local_part@$domain from $sender_host_address
+
 deny    sender_domains = *cloudwaysapps.com
         message = Please use a real sending domain
 


### PR DESCRIPTION
Adds an ACL to reject recipient addresses where the domain has no TLD (e.g. `user@localhost`, `user@Ubuntu24`).

These addresses cannot be delivered to anything public, but without this ACL they still get accepted, queued, attempted, deferred, and eventually bounced. That's purely wasted queue capacity and DNS lookups.

The rule matches any `$domain` containing no `.` character. Applies to all senders including authenticated users; no legitimate sending client should be producing TLD-less recipient addresses.

Placed alongside the existing per-recipient blocks in `check_recipient`.