### PR TITLE
Reject senders without a TLD

### DIFF
--- a/exim/exim.acl_check_recipient.pre.conf
+++ b/exim/exim.acl_check_recipient.pre.conf
@@ -209,6 +209,14 @@ deny    condition = ${if match{$domain}{\N^[^.]+$\N}{yes}{no}}
         message = Recipient domain must be a fully qualified name
         logwrite = Blocked TLD-less recipient: $local_part@$domain from $sender_host_address
 
+# Reject envelope sender domains with no TLD (e.g. root@localhost, user@Ubuntu24).
+# A message accepted with such a sender has no routable return path; bounces cannot
+# be delivered and the message either fails silently or pollutes the queue.
+# Null sender (<>) has an empty $sender_address_domain, which does not match this regex.
+deny    condition = ${if match{$sender_address_domain}{\N^[^.]+$\N}{yes}{no}}
+        message = Envelope sender domain must be a fully qualified name
+        logwrite = Blocked TLD-less sender: $sender_address from $sender_host_address
+
 deny    sender_domains = *cloudwaysapps.com
         message = Please use a real sending domain
 


### PR DESCRIPTION
Adds a symmetric ACL rule to reject envelope sender addresses where the domain has no TLD (e.g. `root@localhost`, `random@Ubuntu24`).

Complements the earlier recipient-side rule. Without this, authenticated users sending with a broken envelope-from (misconfigured cron, `sendmail` CLI output from scripts, etc.) get their messages accepted, queued, and eventually bounced back to an unroutable return path.

Null senders (`<>`) are explicitly not caught; `$sender_address_domain` is empty for null senders and the regex requires at least one non-dot character, so DSN traffic is unaffected.