### PR TITLE
Move hand-maintained ACL data files from /etc to /etc/exim

### DIFF
--- a/exim/add_bulk_acls.sh
+++ b/exim/add_bulk_acls.sh
@@ -2,6 +2,6 @@
 
 rm -f /etc/exim.acl_check_recipient.pre.conf
 wget -O /etc/exim.acl_check_recipient.pre.conf https://raw.githubusercontent.com/mxroute/da_server_updates/refs/heads/master/exim/exim.acl_check_recipient.pre.conf
-rm -f /etc/bannedspoofing
-wget -O /etc/bannedspoofing https://raw.githubusercontent.com/mxroute/da_server_updates/refs/heads/master/exim/bannedspoofing
+rm -f /etc/exim/bannedspoofing
+wget -O /etc/exim/bannedspoofing https://raw.githubusercontent.com/mxroute/da_server_updates/refs/heads/master/exim/bannedspoofing
 killall -9 exim && systemctl restart exim

--- a/exim/check_overquota.sh
+++ b/exim/check_overquota.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-OVERQUOTA_FILE="/etc/overquota"
+OVERQUOTA_FILE="/etc/exim/overquota"
 TEMP_FILE="/tmp/overquota_tmp.$$"
 DEBUG=0  # Set to 1 for debug mode
 

--- a/exim/deploy_helo_blocks.sh
+++ b/exim/deploy_helo_blocks.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-rm -f /etc/heloblocks
+rm -f /etc/exim/heloblocks
 rm -f /etc/exim.acl_check_helo.pre.conf
 cp /root/da_server_updates/exim/exim.acl_check_helo.pre.conf /etc
-cp /root/da_server_updates/exim/heloblocks /etc
+cp /root/da_server_updates/exim/heloblocks /etc/exim/
 killall -9 exim
 systemctl restart exim

--- a/exim/exim.acl_check_helo.pre.conf
+++ b/exim/exim.acl_check_helo.pre.conf
@@ -11,7 +11,7 @@ deny
    message = This computer has been blocked from sending email
 
 drop
-   condition = ${lookup{$sender_helo_name}lsearch{/etc/heloblocks}{yes}{no}}
+   condition = ${lookup{$sender_helo_name}lsearch{/etc/exim/heloblocks}{yes}{no}}
    log_message = HELO/EHLO - HELO on heloblocks Blocklist
    message = This computer has been blocked from sending email
 

--- a/exim/exim.acl_check_message.pre.conf
+++ b/exim/exim.acl_check_message.pre.conf
@@ -77,9 +77,9 @@ deny    condition = ${if match{$h_subject:}{\N~\|\N}{yes}{no}}
 warn
   !authenticated = *
   condition = ${if !eq{$acl_m_is_whitelisted}{1}}
-  condition = ${if exists{/etc/aifilter-domains}}
+  condition = ${if exists{/etc/exim/aifilter-domains}}
   condition = ${lookup{${lc:${domain:$recipients}}}\
-                 lsearch{/etc/aifilter-domains}{yes}{no}}
+                 lsearch{/etc/exim/aifilter-domains}{yes}{no}}
   set acl_m_use_aifilter = yes
   logwrite = AI-FILTER: Checking ${domain:$recipients} via AI filter
 

--- a/exim/exim.acl_check_recipient.pre.conf
+++ b/exim/exim.acl_check_recipient.pre.conf
@@ -48,7 +48,7 @@ deny    condition = ${if and {{eq{$sender_address_domain}{sent.com}} \
 
 # Nice try fuckers
 deny    message   = Envelope sender domain not permitted
-        !senders  = /etc/firebaseapp_whitelist
+        !senders  = /etc/exim/firebaseapp_whitelist
         condition = ${if match{$sender_address_domain}{\N(^|\.)firebaseapp\.com$\N}{yes}{no}}
 
 # Blocking a huge spam trend
@@ -66,7 +66,7 @@ deny    condition = ${if match{$sender_address_domain}{\Ndreamhostps\.com\N}{yes
 
 # Fuck off .solutions spammers
 deny    !authenticated = *
-        !hosts = /etc/solutions_whitelist
+        !hosts = /etc/exim/solutions_whitelist
         condition = ${if match{$sender_helo_name}{\N\.solutions$\N}{yes}{no}}
         message = This message represents a spam trend that matches no non-spam senders
         logwrite = Blocked HELO .solutions: $sender_helo_name from $sender_host_address
@@ -86,15 +86,15 @@ deny    condition = ${if >{$rcpt_fail_count}{25}{yes}{no}}
 
 # First: Critical security checks and spoofing prevention
 # Check domain whitelist
-warn    condition = ${lookup{${domain:$sender_address}}lsearch{/etc/susranges_domainwhitelist}{1}{0}}
+warn    condition = ${lookup{${domain:$sender_address}}lsearch{/etc/exim/susranges_domainwhitelist}{1}{0}}
         set acl_m_domain_whitelisted = 1
 
 # Apply the suspicious range check
 deny    !authenticated = *
-        !hosts = <; /etc/susranges_whitelist
+        !hosts = <; /etc/exim/susranges_whitelist
         !condition = ${if eq{$acl_m_domain_whitelisted}{1}{1}{0}}
-        hosts = <; /etc/susranges
-        condition = ${lookup{$domain}lsearch{/etc/susranges_protected_domains}{1}{0}}
+        hosts = <; /etc/exim/susranges
+        condition = ${lookup{$domain}lsearch{/etc/exim/susranges_protected_domains}{1}{0}}
         logwrite = Rejected suspicious IP: $sender_host_address for protected domain: $domain
         message = Unauthenticated mail not allowed from this range to protected domain, nonspam senders request whitelisting at esf.mxroute.com
 
@@ -128,8 +128,8 @@ deny    spf = fail
 deny    message = Blocking non-whitelisted messages from Google Groups
         !authenticated = *
         condition = ${if match{$sender_address}{\N\+bnc\N}{yes}{no}}
-        !condition = ${if exists{/etc/googlegroups_whitelist}\
-                       {${lookup{${domain:$sender_address}}lsearch{/etc/googlegroups_whitelist}{yes}{no}}}\
+        !condition = ${if exists{/etc/exim/googlegroups_whitelist}\
+                       {${lookup{${domain:$sender_address}}lsearch{/etc/exim/googlegroups_whitelist}{yes}{no}}}\
                        {no}}
         logwrite = Blocked Google Groups sender: $sender_address
 
@@ -161,8 +161,8 @@ deny    message = Mail not accepted from default assigned hostnames
         logwrite = Rejected default OVH hostname: helo=$sender_helo_name host=$sender_host_name from $sender_host_address
 
 deny    !authenticated = *
-        !hosts = <; /etc/aclwhitelist
-        hosts = <; /etc/ovhranges
+        !hosts = <; /etc/exim/aclwhitelist
+        hosts = <; /etc/exim/ovhranges
         condition = ${if match{$sender_helo_name}{\N^mail[0-9]+\.[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)?$\N}{yes}{no}}
         message = Suspicious email trend detected and blocked.
         logwrite = Rejected suspicious OVH host: $sender_host_address with HELO $sender_helo_name
@@ -170,10 +170,10 @@ deny    !authenticated = *
 # Sixth: Authentication-related spoofing checks
 deny    message = Spoofing domains that you do not own to external recipients not allowed
         authenticated = *
-        condition = ${lookup{$sender_address_domain}lsearch{/etc/bannedspoofing}{1}{0}}
+        condition = ${lookup{$sender_address_domain}lsearch{/etc/exim/bannedspoofing}{1}{0}}
         domains = !+local_domains
-        !condition = ${if exists{/etc/spoofwhitelist}\
-                     {${lookup{${domain:$authenticated_id}}lsearch{/etc/spoofwhitelist}{yes}{no}}}\
+        !condition = ${if exists{/etc/exim/spoofwhitelist}\
+                     {${lookup{${domain:$authenticated_id}}lsearch{/etc/exim/spoofwhitelist}{yes}{no}}}\
                      {no}}
         logwrite = SPOOFCHECK: Blocked spoof attempt sender=$sender_address auth=$authenticated_id rcpt=$local_part@$domain
 
@@ -181,13 +181,13 @@ deny    message = Spoofing domains that you do not own to external recipients no
 deny    senders     = *@example.com
         message     = Your software claims your sending address is on example.com which is not your domain
 
-deny    senders     = nwildlsearch*@;/etc/spam_senders
+deny    senders     = nwildlsearch*@;/etc/exim/spam_senders
         message     = Your sending address has been blocked by admins see mxroutedocs.com for explanation
 
-deny    recipients  = nwildlsearch*@;/etc/spam_recipients
+deny    recipients  = nwildlsearch*@;/etc/exim/spam_recipients
         message     = Your recipient address has been blocked by admins see mxroutedocs.com for explanation
 
-deny    recipients  = nwildlsearch*@;/etc/overquota
+deny    recipients  = nwildlsearch*@;/etc/exim/overquota
         message     = Your recipient has reached their disk quota
 
 deny    condition = ${if match{$sender_helo_name}{(?:^|\.)\mxrouting.net}}
@@ -235,12 +235,12 @@ warn    senders = :
 deny    condition = ${if match{$local_part@$domain}{.*@email\.tst.*}{yes}{no}}
         message = Sending to email.tst domains is not allowed
 
-deny    !sender_domains = nwildlsearch;/etc/onmicrosoft_whitelist
+deny    !sender_domains = nwildlsearch;/etc/exim/onmicrosoft_whitelist
         condition = ${if match{$sender_address}{\N.*onmicrosoft\.com\N}{yes}{no}}
         message = Envelope sender containing onmicrosoft.com is not allowed
         logwrite = Blocked onmicrosoft sender: $sender_address from $sender_host_address ($sender_address_domain)
 
 deny    !authenticated = *
         sender_domains = sendgrid.net
-        !condition = ${lookup{$domain}lsearch{/etc/sendgrid_whitelist}{1}{0}}
+        !condition = ${lookup{$domain}lsearch{/etc/exim/sendgrid_whitelist}{1}{0}}
         message = Sendgrid.net sender domains are only allowed to specific whitelisted recipients

--- a/exim/migrate_to_etc_exim.sh
+++ b/exim/migrate_to_etc_exim.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+#
+# migrate_to_etc_exim.sh
+#
+# One-time migration: move MXroute-maintained exim data files from /etc/
+# to /etc/exim/ so the full ACL data surface lives under one directory
+# that can be rsynced to a new server.
+#
+# Safe to re-run. For each file:
+#   - If old path doesn't exist: skip.
+#   - If new path doesn't exist: move old -> new.
+#   - If both exist and are identical: remove old.
+#   - If both exist and differ: stop and warn (manual reconcile).
+#
+# Run on each server once before deploying the updated ACL/config files.
+
+set -u
+
+DEST_DIR="/etc/exim"
+
+FILES=(
+    aclwhitelist
+    aifilter-domains
+    bannedspoofing
+    firebaseapp_whitelist
+    googlegroups_whitelist
+    heloblocks
+    onmicrosoft_whitelist
+    overquota
+    ovhranges
+    sendgrid_whitelist
+    solutions_whitelist
+    spam_recipients
+    spam_senders
+    spoofwhitelist
+    susranges
+    susranges_domainwhitelist
+    susranges_protected_domains
+    susranges_whitelist
+)
+
+if [[ ! -d "$DEST_DIR" ]]; then
+    mkdir -p "$DEST_DIR"
+    echo "Created $DEST_DIR"
+fi
+
+moved=0
+skipped=0
+identical=0
+conflicts=()
+
+for name in "${FILES[@]}"; do
+    old="/etc/$name"
+    new="$DEST_DIR/$name"
+
+    if [[ ! -e "$old" ]]; then
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    if [[ ! -e "$new" ]]; then
+        mv "$old" "$new"
+        echo "Moved $old -> $new"
+        moved=$((moved + 1))
+        continue
+    fi
+
+    # Both exist. Compare.
+    if cmp -s "$old" "$new"; then
+        rm -f "$old"
+        echo "Removed $old (identical to $new)"
+        identical=$((identical + 1))
+    else
+        conflicts+=("$name")
+        echo "CONFLICT: $old and $new both exist and differ. Not touched." >&2
+    fi
+done
+
+echo
+echo "Summary: moved=$moved identical=$identical skipped=$skipped conflicts=${#conflicts[@]}"
+
+if (( ${#conflicts[@]} > 0 )); then
+    echo
+    echo "Conflicts to reconcile manually:" >&2
+    for c in "${conflicts[@]}"; do
+        echo "  diff /etc/$c $DEST_DIR/$c" >&2
+    done
+    exit 1
+fi
+
+echo
+echo "Migration complete. Remember to:"
+echo "  - Deploy the updated ACL/config files that reference /etc/exim/*"
+echo "  - Restart exim:  killall -9 exim && systemctl restart exim"

--- a/exim/quotamitigation.sh
+++ b/exim/quotamitigation.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-grep "mailbox for user is full" /var/log/exim/mainlog | awk -F'TO:' '{print $2}' | awk '{print $1}' | sed 's/<//' | sed 's/>://' | sort | uniq -c | sort -n | tail -25 | awk '{print $2}' >> /etc/overquota
+grep "mailbox for user is full" /var/log/exim/mainlog | awk -F'TO:' '{print $2}' | awk '{print $1}' | sed 's/<//' | sed 's/>://' | sort | uniq -c | sort -n | tail -25 | awk '{print $2}' >> /etc/exim/overquota

--- a/exim/update_acls.sh
+++ b/exim/update_acls.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-rm -f /etc/spam_recipients
-cp /root/da_server_updates/exim/spam_recipients /etc
+rm -f /etc/exim/spam_recipients
+cp /root/da_server_updates/exim/spam_recipients /etc/exim/
 rm -f /etc/exim.acl_check_recipient.pre.conf
 cp /root/da_server_updates/exim/exim.acl_check_recipient.pre.conf /etc
 rm -f /etc/exim.acl_check_message.pre.conf

--- a/exim/update_spam_recipients.sh
+++ b/exim/update_spam_recipients.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-wget https://raw.githubusercontent.com/mxroute/da_server_updates/master/exim/spam_recipients -O /etc/spam_recipients
+wget https://raw.githubusercontent.com/mxroute/da_server_updates/master/exim/spam_recipients -O /etc/exim/spam_recipients

--- a/sec/suswlunblock.sh
+++ b/sec/suswlunblock.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-for i in $(cat /etc/susranges_whitelist); do ip route del blackhole $i; done
+for i in $(cat /etc/exim/susranges_whitelist); do ip route del blackhole $i; done

--- a/spamassassin/update_rules.sh
+++ b/spamassassin/update_rules.sh
@@ -2,5 +2,5 @@
 rm -f /etc/mail/spamassassin/local.cf
 wget https://raw.githubusercontent.com/mxroute/da_server_updates/master/spamassassin/local.cf -P /etc/mail/spamassassin
 systemctl restart spamd
-rm -f /etc/susranges
-wget https://raw.githubusercontent.com/mxroute/da_server_updates/refs/heads/master/exim/susranges -P /etc
+rm -f /etc/exim/susranges
+wget https://raw.githubusercontent.com/mxroute/da_server_updates/refs/heads/master/exim/susranges -P /etc/exim/


### PR DESCRIPTION
Consolidates the 18 hand-maintained ACL data files into `/etc/exim/` so the full exim data surface can be rsynced as one directory to a new server.

## What changed

**ACL configs (path references):**
- `exim/exim.acl_check_helo.pre.conf` — heloblocks
- `exim/exim.acl_check_message.pre.conf` — aifilter-domains
- `exim/exim.acl_check_recipient.pre.conf` — aclwhitelist, bannedspoofing, firebaseapp_whitelist, googlegroups_whitelist, onmicrosoft_whitelist, overquota, ovhranges, sendgrid_whitelist, solutions_whitelist, spam_recipients, spam_senders, spoofwhitelist, susranges, susranges_domainwhitelist, susranges_protected_domains, susranges_whitelist

**Deploy/maintenance scripts updated to read from and write to the new path:**
- `exim/add_bulk_acls.sh`
- `exim/check_overquota.sh`
- `exim/deploy_helo_blocks.sh`
- `exim/quotamitigation.sh`
- `exim/update_acls.sh`
- `exim/update_spam_recipients.sh`
- `sec/suswlunblock.sh`
- `spamassassin/update_rules.sh`

**New migration script:** `exim/migrate_to_etc_exim.sh` — idempotent per-server migration.

## Migration procedure per server

1. Run `exim/migrate_to_etc_exim.sh` on the server. It moves each file from `/etc/` to `/etc/exim/` if the old path exists and the new one doesn't. If both exist and are identical, it removes the old copy. If both exist and differ, it stops and asks for manual reconcile (should not happen unless the server was partially migrated already).
2. Deploy the updated ACL `.pre.conf` files.
3. `killall -9 exim && systemctl restart exim`

Safe to run the migration script multiple times; subsequent runs become no-ops once files have moved.

## What was NOT changed

- Files already under `/etc/exim/` (`gmail_estimation_whitelist`, `tld_whitelist`, `local_part_suffix.conf`, `opendmarc.tlds`, `virtual_localdelivery.conf.post`) — already in the right place.
- DA-managed paths (`/etc/virtual/*`, `/etc/aliases`, `/etc/passwd`).
- DA-generated exim config fragments (`/etc/exim.*`) — those stay where DA expects them.
- `/etc/exim.pl`, `/etc/system_filter.exim` — left alone; out of scope.