### PR TITLE
Keep susranges_protected_domains in /etc

### DIFF
--- a/exim/exim.acl_check_recipient.pre.conf
+++ b/exim/exim.acl_check_recipient.pre.conf
@@ -94,7 +94,7 @@ deny    !authenticated = *
         !hosts = <; /etc/exim/susranges_whitelist
         !condition = ${if eq{$acl_m_domain_whitelisted}{1}{1}{0}}
         hosts = <; /etc/exim/susranges
-        condition = ${lookup{$domain}lsearch{/etc/exim/susranges_protected_domains}{1}{0}}
+        condition = ${lookup{$domain}lsearch{/etc/susranges_protected_domains}{1}{0}}
         logwrite = Rejected suspicious IP: $sender_host_address for protected domain: $domain
         message = Unauthenticated mail not allowed from this range to protected domain, nonspam senders request whitelisting at esf.mxroute.com
 

--- a/exim/migrate_to_etc_exim.sh
+++ b/exim/migrate_to_etc_exim.sh
@@ -35,7 +35,6 @@ FILES=(
     spoofwhitelist
     susranges
     susranges_domainwhitelist
-    susranges_protected_domains
     susranges_whitelist
 )
 


### PR DESCRIPTION
Reverts susranges_protected_domains back to /etc. Has external writers (DA hooks and panel.mxroute.com) that assume /etc; moving it would break both without coordinated changes.