### PR TITLE
Add Outlook .nic sender ACL

### DIFF
--- a/exim/exim.acl_check_recipient.pre.conf
+++ b/exim/exim.acl_check_recipient.pre.conf
@@ -11,6 +11,15 @@ deny    !authenticated = *
         !condition = ${lookup{$sender_address}lsearch{/etc/exim/gmail_estimation_whitelist}{yes}{no}}
         message = Likely spam rejected
 
+# Block Outlook/Hotmail .nic[digits] spam campaign
+# Examples seen across the fleet: name.nic@outlook.com, name.nic56@outlook.com.
+# This runs at RCPT time, before Subject/body are available.
+deny    !authenticated = *
+        condition = ${if and {{match{${lc:$sender_address_domain}}{\N^(outlook|hotmail)\.com$\N}} \
+                          {match{${lc:$sender_address_local_part}}{\N\.nic[0-9]*$\N}}}{yes}{no}}
+        message = Message rejected
+        logwrite = Blocked Outlook/Hotmail .nic spam trend: sender=$sender_address from $sender_host_address recipient=$local_part@$domain
+
 # No.
 deny    !authenticated = *
         condition = ${if match{$sender_address_domain}{\N\.(bond|space)$\N}}


### PR DESCRIPTION
Adds an Exim recipient ACL rule for the observed Outlook/Hotmail .nic sender pattern.\n\nLocal validation: exim binary is not installed in this workspace, so config parse was not run here.