### PR TITLE
Exclude verified brand senders from prefix block

### DIFF
--- a/exim/exim.acl_check_recipient.pre.conf
+++ b/exim/exim.acl_check_recipient.pre.conf
@@ -26,6 +26,7 @@ deny    !authenticated = *
 
 # Block common spam local part prefixes
 deny    !authenticated = *
+        condition = ${if match{${lc:$sender_address_domain}}{\N^(email-marriott\.com|marriott\.com|bcbsms\.com|feedback\.bcbsnc\.com)$\N}{no}{yes}}
         condition = ${if match{${lc:$sender_address_local_part}}{\N^(bluecross|biuecross|cstcco|cocstcspecia|teamsams|fedexitem|aaacourtesy|clubteamsam|samsshoppingteam|samsteam|clubsams|samsclub|omahasample|omahasteak|steaksample|AmericanSecureOnline|aaaroadhelp|cstc|blueshield|b(l|i)uecross|lowes|samsmember|marriot)\N}{yes}{no}}
         message = Message rejected
         logwrite = Blocked sender: $sender_address from $sender_host_address


### PR DESCRIPTION
Adds exact sender-domain exclusions for verified legitimate brand mail caught by the local-part prefix block.