### PR TITLE
Whitelist Walmart senders in localpart ACL

### DIFF
--- a/exim/exim.acl_check_recipient.pre.conf
+++ b/exim/exim.acl_check_recipient.pre.conf
@@ -25,8 +25,9 @@ deny    !authenticated = *
         message = Yeah no
 
 # Block common spam local part prefixes
+# Keep known legitimate brand senders out of this broad local-part trap.
 deny    !authenticated = *
-        condition = ${if match{${lc:$sender_address_domain}}{\N^(email-marriott\.com|marriott\.com|bcbsms\.com|feedback\.bcbsnc\.com)$\N}{no}{yes}}
+        condition = ${if match{${lc:$sender_address_domain}}{\N^(email-marriott\.com|marriott\.com|bcbsms\.com|feedback\.bcbsnc\.com|ib\.transaction\.walmart\.com|prod\.walmart\.com|abmail\.em\.walmart\.com|bounce\.e\.walmart\.ca|express4\.medallia\.com|prod\.walmart\.ca|bf56x\.hubspotemail\.net|es\.relay\.walmart\.com|ib\.transaction\.walmart\.ca|relay\.walmart\.com|bounce\.comms\.walmart\.com|bulk\.walmart\.com|mail\.pharmacy\.walmart\.ca|sparkcommunity\.walmartluminate\.com|walmart\.com|delivery\.em\.walmartbusiness\.com|bounce\.em\.samsclub\.com|ib\.transaction\.es\.relay\.walmart\.com|mail\.m\.myphotos\.walmart\.com|e\.update\.one\.app|e\.account\.onepay\.com)$\N}{no}{yes}}
         condition = ${if match{${lc:$sender_address_local_part}}{\N^(walmart|bluecross|biuecross|cstcco|cocstcspecia|teamsams|fedexitem|aaacourtesy|clubteamsam|samsshoppingteam|samsteam|clubsams|samsclub|omahasample|omahasteak|steaksample|AmericanSecureOnline|aaaroadhelp|cstc|blueshield|b(l|i)uecross|lowes|samsmember|marriot)\N}{yes}{no}}
         message = Message rejected
         logwrite = Blocked sender: $sender_address from $sender_host_address


### PR DESCRIPTION
Adds known legitimate Walmart and adjacent sender domains to the local-part spam trap whitelist.