### PR TITLE
Block dpdns.org subdomain spam

### DIFF
--- a/exim/exim.acl_check_recipient.pre.conf
+++ b/exim/exim.acl_check_recipient.pre.conf
@@ -18,6 +18,16 @@ deny    !authenticated = *
         message = Message rejected
         logwrite = Blocked Outlook/Hotmail .nic spam trend: sender=$sender_address from $sender_host_address recipient=$local_part@$domain
 
+# Block dpdns.org dynamic DNS spam campaign
+deny    !authenticated = *
+        condition = ${if or{\
+                          {match{${lc:$sender_address_domain}}{\N.+\.dpdns\.org$\N}}\
+                          {match{${lc:$sender_helo_name}}{\N.+\.dpdns\.org$\N}}\
+                          {match{${lc:$sender_host_name}}{\N.+\.dpdns\.org$\N}}\
+                         }{yes}{no}}
+        message = Message rejected
+        logwrite = Blocked dpdns.org spam trend: sender=$sender_address helo=$sender_helo_name host=$sender_host_name from $sender_host_address recipient=$local_part@$domain
+
 # No.
 deny    !authenticated = *
         condition = ${if match{$sender_address_domain}{\N\.(bond|space)$\N}}


### PR DESCRIPTION
Adds a recipient ACL rule to reject unauthenticated mail using dpdns.org subdomains in the envelope sender domain, HELO, or reverse hostname.